### PR TITLE
fix: add check_mode in localhost binary cache task

### DIFF
--- a/roles/_common/tasks/install.yml
+++ b/roles/_common/tasks/install.yml
@@ -52,6 +52,7 @@
     state: directory
     mode: 0755
   delegate_to: localhost
+  check_mode: false
   tags:
     - "{{ ansible_parent_role_names | first | regex_replace(ansible_collection_name ~ '.', '') }}"
     - install


### PR DESCRIPTION
This PR adds the `check_mode: false` in the localhost binary cache task.

This change is necessary because the next task, which downloads the prometheus binary, relies on this folder being created in advance. Since the task lacked the `check_mode: false`, it only simulated execution without actually creating the required folder.

This code was introduced in the most recent PR: https://github.com/prometheus-community/ansible/pull/425/files#diff-c9a8a7fbd7ee9c40d13e4be2e88801e621b943a2246b78ad46b93dc0f7c33971R38

You can see that this task did not exist before: https://github.com/prometheus-community/ansible/pull/425/files#diff-6f9278158452a81913bff59d794daa00e142796b04e75efd873c4a5dbb7f2899L38